### PR TITLE
Typo in readme making diamond db

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone https://github.com/borenstein-lab/IFDP.git
 
 ```
 gunzip ec_full.fasta.gz;
-diamond makedb --in ec_full.fasta.gz -d ec_full
+diamond makedb --in ec_full.fasta -d ec_full
 ```
 4.Test the installation by running this example:
 


### PR DESCRIPTION
After you unzip fasta file, cant build diamond db on .gz file...it got unzipped in previous line. (the publication was awesome, looking forward to trying this out, thanks).